### PR TITLE
Use correct package name in demo import statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ npm install react-android-style-toast --save
 ## Usage
 
 ```js
-import { toast } from 'react-notify-toast';
+import { toast } from 'react-android-style-toast';
 
 toast.show('toast message');
 ```


### PR DESCRIPTION
I think this was just a mistake as the package name in
the example is for a different package:

https://www.npmjs.com/package/react-notify-toast

If I misread this, I apologize. Thanks for the awesome 
work either way!